### PR TITLE
feat: change junit scope to test, upgrade vavr version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
         <junit.version>4.12</junit.version>
-        <vavr.version>0.9.0</vavr.version>
+        <vavr.version>0.10.2</vavr.version>
     </properties>
 
     <dependencies>
@@ -60,6 +60,7 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.vavr</groupId>


### PR DESCRIPTION
1. java-datatable in nexus repository includes junit, which should not be included.
2. upgrade vavr version to latest version